### PR TITLE
Fix `img` for circumgraph

### DIFF
--- a/index.html
+++ b/index.html
@@ -190,7 +190,7 @@ section h2 {
 
 <p><dfn class="lint-ignore export">Character set</dfn> or <span class="alt_name">repertoire</span>. The set of characters one might use for a particular purpose – be it those required to support Western European languages in computers, or those a Chinese child will learn at school in the third grade (nothing to do with computers).</p>
 
-<p><dfn class="lint-ignore export">Circumgraph</dfn>. A single vowel code point that produces glyphs on more than one side of its consonant base. For example, in the Odia syllable <img src="img/circumgraph.svg" alt="କୋ" style="height:1.2rem;" height="20rem" width="34.8rem">, /ka/, the character <span class="codepoint" translate="no"><bdi lang="or">&#x0B4B;</bdi><span class="uname">U+0B4B ORIYA VOWEL SIGN O</span></span> produces separate glyphs on either side of the base consonant.</p>
+<p><dfn class="lint-ignore export">Circumgraph</dfn>. A single vowel code point that produces glyphs on more than one side of its consonant base. For example, in the Odia syllable <img src="img/circumgraph.svg" alt="କୋ" style="height:1.2rem;">, /ka/, the character <span class="codepoint" translate="no"><bdi lang="or">&#x0B4B;</bdi><span class="uname">U+0B4B ORIYA VOWEL SIGN O</span></span> produces separate glyphs on either side of the base consonant.</p>
 
 <p><dfn class="lint-ignore">CJK</dfn>. An abbreviation for Chinese, Japanese, and Korean. Sometimes CJKV is used to include the Han characters used in Vietnamese.</p>
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/aphillips/i18n-glossary/pull/43.html" title="Last updated on Apr 22, 2023, 8:12 AM UTC (63e439c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/i18n-glossary/43/2bf0f12...aphillips:63e439c.html" title="Last updated on Apr 22, 2023, 8:12 AM UTC (63e439c)">Diff</a>