### PR TITLE
Fix doc for publication

### DIFF
--- a/echidna
+++ b/echidna
@@ -1,5 +1,4 @@
 # ECHIDNA configuration
 index.html?specStatus=DNOTE&shortName=i18n-glossary respec
-https://w3c.github.io/i18n-drafts/style/respec_2022.css
 local.css
 img/circumgraph.svg

--- a/echidna
+++ b/echidna
@@ -1,4 +1,3 @@
 # ECHIDNA configuration
 index.html?specStatus=DNOTE&shortName=i18n-glossary respec
-local.css
 img/circumgraph.svg

--- a/index.html
+++ b/index.html
@@ -39,7 +39,8 @@
 		  
           };
     </script>
-<link rel="stylesheet" data-import href="https://w3c.github.io/i18n-drafts/style/respec_2022.css">
+ 
+<!--link rel="stylesheet" data-import href="https://w3c.github.io/i18n-drafts/style/respec_2022.css"-->
 <link rel="stylesheet" data-import href="local.css">
 <style>
 .letter_anchor {

--- a/index.html
+++ b/index.html
@@ -31,8 +31,6 @@
                 { name: "Richard Ishida", mailto: "ishida@w3.org", company: "W3C", w3cid: 3439 },
                 { name: "Addison Phillips", mailto: "addisonI18N@gmail.com", company: "Invited Expert", w3cid: 33573 }
                 ],
-         
-
 		
 		  github: "w3c/i18n-glossary",
 		  group: "i18n",
@@ -40,8 +38,12 @@
           };
     </script>
  
-<!--link rel="stylesheet" data-import href="https://w3c.github.io/i18n-drafts/style/respec_2022.css"-->
-<link rel="stylesheet" data-import href="local.css">
+<!-- 
+      The ReSpec attribute 'data-include' loads the contents of the CSS files into the
+      'style' element provided when generating the output page.
+  -->
+<style data-include="https://w3c.github.io/i18n-drafts/style/respec_2022.css"></style>
+<style data-include="https://w3c.github.io/i18n-glossary/local.css"></style>
 <style>
 .letter_anchor {
     font-weight: bold;


### PR DESCRIPTION
Somehow we have a link to i18n-drafts/style/respec_2022.css in the doc. This violates specberus rules. The stylesheet in question doesn't appear to be important to the functionality of the document. This is the only thing blocking me pushing to TR. (I did some "quick fixes" without waiting for review, but want to validate what we're doing and what I'm not understanding with the PR before I push the glossary up to TR again--and before I probably run into similar with specdev)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/aphillips/i18n-glossary/pull/46.html" title="Last updated on Apr 24, 2023, 3:51 PM UTC (dc0d798)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/i18n-glossary/46/1e8d830...aphillips:dc0d798.html" title="Last updated on Apr 24, 2023, 3:51 PM UTC (dc0d798)">Diff</a>